### PR TITLE
Allow rmcguiness.com to embed site in iframe

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,7 +18,7 @@ export async function middleware(request: NextRequest) {
     object-src 'none';
     base-uri 'self';
     form-action 'self';
-    frame-ancestors https://rmcguiness.com https://mcg-consulting.vercel.app https://mcg-consulting.xyz/;
+    frame-ancestors 'self' https://rmcguiness.com https://www.rmcguiness.com http://rmcguiness.com http://www.rmcguiness.com https://mcg-consulting.vercel.app https://mcg-consulting.xyz;
     upgrade-insecure-requests;
   `;
 	// Replace newline characters and spaces


### PR DESCRIPTION
Fixes blank portfolio preview on resume site.

## Changes
- Updated CSP `frame-ancestors` directive to allow rmcguiness.com domains
- Added both http/https variants and www subdomain
- Added 'self' to allow embedding on same domain
- Fixed trailing slash inconsistency

## Why
The resume site (rmcguiness.com) displays portfolio items using iframes to show live previews. The CSP policy was blocking this, causing blank previews.

## Testing
After deployment:
1. Visit rmcguiness.com portfolio section
2. Verify next-playground iframe loads correctly
3. Check browser console for CSP errors (should be none)