### PR TITLE
Move menu to left side and convert to popover

### DIFF
--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -13,42 +13,7 @@ export default async function NavBar() {
   return (
     <nav className="bg-background shadow-lg p-4 fixed w-full z-10">
       <div className="max-w-7xl mx-auto flex justify-between items-center">
-        <Link href="/" className="flex items-center space-x-2">
-          <div className="bg-green-600 text-background p-2 rounded-md">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </div>
-          <span className="text- text-xl font-bold tracking-tight hidden md:inline">
-            Next<span className="text-green-500">Playground</span>
-          </span>
-        </Link>
         <div className="flex items-center space-x-3">
-          <ThemeSwitcher />
-          {!isLoggedIn && (
-            <div className="hidden sm:flex items-center space-x-3">
-              <CustomButton
-                text="Login"
-                endpt="/auth/login"
-                className="text-foreground bg-background hover:border-foreground hover:shadow-lg px-5 py-2 rounded-full transition duration-300"
-              />
-              <CustomButton
-                text="Sign Up"
-                endpt="/auth/signup"
-                className="text-background bg-linear-to-r from-green-600 to-green-500 hover:from-green-400 hover:to-green-300 px-5 py-2 rounded-full hover:shadow-sm transition duration-300"
-              />
-            </div>
-          )}
-
           <MenuDropdown>
             {/* Tech Demos Section */}
             <DropDown label="Tech Demos">
@@ -251,6 +216,42 @@ export default async function NavBar() {
               />
             </div>
           </MenuDropdown>
+          <Link href="/" className="flex items-center space-x-2">
+            <div className="bg-green-600 text-background p-2 rounded-md">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </div>
+            <span className="text- text-xl font-bold tracking-tight hidden md:inline">
+              Next<span className="text-green-500">Playground</span>
+            </span>
+          </Link>
+        </div>
+        <div className="flex items-center space-x-3">
+          <ThemeSwitcher />
+          {!isLoggedIn && (
+            <div className="hidden sm:flex items-center space-x-3">
+              <CustomButton
+                text="Login"
+                endpt="/auth/login"
+                className="text-foreground bg-background hover:border-foreground hover:shadow-lg px-5 py-2 rounded-full transition duration-300"
+              />
+              <CustomButton
+                text="Sign Up"
+                endpt="/auth/signup"
+                className="text-background bg-linear-to-r from-green-600 to-green-500 hover:from-green-400 hover:to-green-300 px-5 py-2 rounded-full hover:shadow-sm transition duration-300"
+              />
+            </div>
+          )}
         </div>
       </div>
     </nav>

--- a/src/components/navbar/components/menu-dropdown.tsx
+++ b/src/components/navbar/components/menu-dropdown.tsx
@@ -27,44 +27,79 @@ export default function MenuDropdown({ children }: MenuDropdownProps) {
     };
   }, [isOpen]);
 
+  // Close on Escape key
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isOpen) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+      // Prevent body scroll when popover is open
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen]);
+
   const toggleDropdown = () => {
     setIsOpen(!isOpen);
   };
 
   return (
-    <div className="relative" ref={dropdownRef}>
-      <button
-        onClick={toggleDropdown}
-        className="flex items-center space-x-2 text-foreground bg-background-1 hover:bg-background-2 px-6 py-2 rounded-full transition duration-300 focus:outline-1"
-      >
-        <span>Menu</span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className={`h-5 w-5 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
+    <>
+      {/* Backdrop overlay */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black/20 backdrop-blur-sm z-40 transition-opacity duration-300"
+          onClick={() => setIsOpen(false)}
+        />
+      )}
+
+      <div className="relative" ref={dropdownRef}>
+        <button
+          onClick={toggleDropdown}
+          className="flex items-center space-x-2 text-foreground bg-background-1 hover:bg-background-2 px-4 py-2 rounded-lg transition duration-300 focus:outline-none focus:ring-2 focus:ring-green-500/50"
+          aria-label="Toggle menu"
+          aria-expanded={isOpen}
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
-      </button>
-      <div
-        className={`absolute right-0 mt-2 w-56 bg-background-1 rounded-lg shadow-xl transition-all duration-300 transform origin-top-right ${
-          isOpen
-            ? "opacity-100 visible translate-y-0"
-            : "opacity-0 invisible translate-y-2 pointer-events-none"
-        }`}
-      >
-        <div className="pt-2">
-          {children}
+          {/* Hamburger icon */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d={isOpen ? "M6 18L18 6M6 6l12 12" : "M4 6h16M4 12h16M4 18h16"}
+            />
+          </svg>
+          <span className="hidden sm:inline">Menu</span>
+        </button>
+
+        {/* Popover menu */}
+        <div
+          className={`fixed left-4 top-20 w-72 bg-background border border-gray-200 dark:border-gray-700 rounded-xl shadow-2xl transition-all duration-300 transform z-50 ${
+            isOpen
+              ? "opacity-100 visible translate-y-0 scale-100"
+              : "opacity-0 invisible -translate-y-4 scale-95 pointer-events-none"
+          }`}
+        >
+          <div className="max-h-[calc(100vh-6rem)] overflow-y-auto">
+            {children}
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Implements menu UI improvements:

**Changes:**
- Moved MenuDropdown from right side to left (before logo)
- Converted traditional dropdown to modern popover with:
  - Backdrop overlay with blur effect
  - Fixed positioning for better UX
  - Hamburger icon that animates to X when open
  - Escape key support
  - Body scroll lock when open
  - Smooth scale + translate animations
  - Improved shadows and spacing

**Related Task:**
From ideas-and-tasks.md:
- [x] Move hamburger/dropdown menu to left side of navbar
- [x] Convert dropdown to popover (similar to OpenClaw docs)

**Preview:**
Check Vercel preview deployment once it completes.